### PR TITLE
Portability / more command-line output

### DIFF
--- a/shp2es.js
+++ b/shp2es.js
@@ -1,4 +1,4 @@
-#!/Users/marinj/homebrew/bin/node
+#!/usr/bin/env node
 
 'use strict';
 

--- a/shp2es.js
+++ b/shp2es.js
@@ -4,25 +4,35 @@
 
 var program = require('commander');
 var shp = require('./lib/shp');
+var errorText = ''
 
 program
   .version('1.0.0')
 	.option('-s, --shapefile <s>', 'Shapefile')
 	.option('-h, --host <h>', 'ElasticSearch host')
 	.option('-p ,--port <p>', 'ElasticSearch port', parseInt)
-	.parse(process.argv);
-
-	if (program.shapefile === undefined ||
-      program.host === undefined ||
-      program.port === undefined) {
-		usage();
-		return;
-	} else {
-		shp.read(program.shapefile, program.host, program.port);
-		return;
-	}
+  .parse(process.argv);
 
 
-function usage() {
-  console.log('usage: shp2es -s <shapefile> -h <ElasticSearch host> -p <ElasticSearch port>');
+if(!program.shapefile || !program.shapefile.match(/\.shp$/i)){
+  errorText += 'Invalid shapefile.\n';
+}
+
+if(!program.host){
+  errorText += 'Must provide an elasticsearch host';
+}
+
+if(!program.port || program.port < -1 || program.port > 65536){
+  errorText += 'Must provide a port number between 0 and 65535';
+}
+
+
+if (errorText) return usage(errorText);
+
+return shp.read(program.shapefile, program.host, program.port);
+
+
+function usage(error) {
+  console.log(error);
+  console.log('usage: ./shp2es -s <shapefile> -h <ElasticSearch host> -p <ElasticSearch port>');
 }

--- a/shp2es.js
+++ b/shp2es.js
@@ -19,11 +19,11 @@ if(!program.shapefile || !program.shapefile.match(/\.shp$/i)){
 }
 
 if(!program.host){
-  errorText += 'Must provide an elasticsearch host';
+  errorText += 'Must provide an elasticsearch host.\n';
 }
 
 if(!program.port || program.port < -1 || program.port > 65536){
-  errorText += 'Must provide a port number between 0 and 65535';
+  errorText += 'Must provide a port number between 0 and 65535.\n';
 }
 
 


### PR DESCRIPTION
Changed the shebang to look at /usr/bin/env which will find the node executable in each user's path.

Also, made the usage fn a bit more verbose (although the code is somewhat uglier).

I'd say this module is a great start to pumping data into es. Once we have the data_spec hammered out we can extend this to take pluggable modules that transform the shapefile output into our preferred format.
